### PR TITLE
Fix values.yaml discovery

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -110,7 +110,7 @@ function getWordAt(str: string, pos: number): string {
  * Retrieves the values from the `values.yaml`.
  */
 function getValuesFromFile(document: vscode.TextDocument): any {
-	const pathToValuesFile = document.fileName.substr(0, document.fileName.indexOf('/templates')) + "/values.yaml";
+	const pathToValuesFile = document.fileName.substr(0, document.fileName.lastIndexOf('/templates')) + "/values.yaml";
 	return yaml.safeLoad(fs.readFileSync(pathToValuesFile, 'utf8'));
 }
 


### PR DESCRIPTION
Fixes a bug where the values file wouldn't be found when the chart path contains another `templates` directory. Previously would not find the `values.yaml` for a path such as `/home/templates/foo/bar/helm-chart/templates/values.yaml`.