### PR TITLE
🚸 changed from printing to output to problems tab

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,11 +35,12 @@ export function activate(context: vscode.ExtensionContext): void {
         vscode.languages.registerCompletionItemProvider(lang, new VariableCompletionItemProvider(), '$');
     }
 
-    const outputChannel = vscode.window.createOutputChannel('Helm-Intellisense');
-    const lintCommand = vscode.commands.registerCommand(LINT_COMMAND_STRING, () => LintCommand(outputChannel));
+    const collection = vscode.languages.createDiagnosticCollection("Helm-Intellisense")
+    
+    const lintCommand = vscode.commands.registerCommand(LINT_COMMAND_STRING, () => LintCommand(collection));
     context.subscriptions.push(lintCommand);
 
-    const lintChartCommand = vscode.commands.registerCommand(LINT_CHART_COMMAND_STRING, () => LintChartCommand(outputChannel));
+    const lintChartCommand = vscode.commands.registerCommand(LINT_CHART_COMMAND_STRING, () => LintChartCommand(collection));
     context.subscriptions.push(lintChartCommand);
 
     vscode.workspace.onDidSaveTextDocument(() => {

--- a/src/test/suite/linter.test.ts
+++ b/src/test/suite/linter.test.ts
@@ -12,24 +12,24 @@ suite('Test Linter', () => {
 
     test('getAllKeyPathsOfDocument()', async () => {
         const doc = await vscode.workspace.openTextDocument(filePath + '/templates/deployment.yaml');
-        const keys = linter.getAllKeyPathsOfDocument(doc);
+        const keys = linter.getAllKeyPathElementsOfDocument(doc);
 
-        const shouldTouples: [string, number][] = [
-            ['.Values.replicaCount', 7],
-            ['.Values.imagePullSecrets', 18],
-            ['.Values.podSecurityContext', 24],
-            ['.Values.securityContext', 28],
-            ['.Values.image.repository', 29],
-            ['.Values.image.tag', 29],
-            ['.Values.image.pullPolicy', 30],
-            ['.Values.resources', 44],
-            ['.Values.nodeSelector', 45],
-            ['.Values.affinity', 49],
-            ['.Values.tolerations', 53],
-            ['.Values.', 57],
-            ['.Values.imag', 58]
+        const shouldTouples: linter.Element[] = [
+            { name: '.Values.replicaCount', line: 7, range: new vscode.Range(new vscode.Position(7, 15), new vscode.Position(7, 35)), type: linter.ElementType.KEY_PATH},
+            { name: '.Values.imagePullSecrets', line: 18, range: new vscode.Range(new vscode.Position(18, 13), new vscode.Position(18, 37)), type: linter.ElementType.KEY_PATH},
+            { name: '.Values.podSecurityContext', line: 24, range: new vscode.Range(new vscode.Position(24, 19), new vscode.Position(24, 45)), type: linter.ElementType.KEY_PATH},
+            { name: '.Values.securityContext', line: 28, range: new vscode.Range(new vscode.Position(28, 23), new vscode.Position(28, 46)), type: linter.ElementType.KEY_PATH},
+            { name: '.Values.image.repository', line: 29, range: new vscode.Range(new vscode.Position(29, 21), new vscode.Position(29, 45)), type: linter.ElementType.KEY_PATH},
+            { name: '.Values.image.tag', line: 29, range: new vscode.Range(new vscode.Position(29, 53), new vscode.Position(29, 70)), type: linter.ElementType.KEY_PATH},
+            { name: '.Values.image.pullPolicy', line: 30, range: new vscode.Range(new vscode.Position(30, 30), new vscode.Position(30, 54)), type: linter.ElementType.KEY_PATH},
+            { name: '.Values.resources', line: 44, range: new vscode.Range(new vscode.Position(44, 23), new vscode.Position(44, 40)), type: linter.ElementType.KEY_PATH},
+            { name: '.Values.nodeSelector', line: 45, range: new vscode.Range(new vscode.Position(45, 15), new vscode.Position(45, 35)), type: linter.ElementType.KEY_PATH},
+            { name: '.Values.affinity', line: 49, range: new vscode.Range(new vscode.Position(49, 13), new vscode.Position(49, 29)), type: linter.ElementType.KEY_PATH},
+            { name: '.Values.tolerations', line: 53, range: new vscode.Range(new vscode.Position(53, 13), new vscode.Position(53, 32)), type: linter.ElementType.KEY_PATH},
+            { name: '.Values.', line: 57, range: new vscode.Range(new vscode.Position(57, 3), new vscode.Position(57, 11)), type: linter.ElementType.KEY_PATH},
+            { name: '.Values.imag', line: 58, range: new vscode.Range(new vscode.Position(58, 3), new vscode.Position(58, 15)), type: linter.ElementType.KEY_PATH}
         ];
-        compareTouples(keys, shouldTouples);
+        compare(keys, shouldTouples);
     });
 
     test('getInvalidKeyPaths()', async () => {
@@ -37,28 +37,35 @@ suite('Test Linter', () => {
         const values = utils.getValuesFromFile(valuesFile.fileName);
 
         const docDeployment = await vscode.workspace.openTextDocument(filePath + '/templates/deployment.yaml');
-        const missingKeysDeployment = linter.getInvalidKeyPaths(linter.getAllKeyPathsOfDocument(docDeployment), values, docDeployment);
+        const missingKeysDeployment = linter.getInvalidKeyPaths(linter.getAllKeyPathElementsOfDocument(docDeployment), values, docDeployment);
         assert.strictEqual(missingKeysDeployment.length, 2);
 
         const docService = await vscode.workspace.openTextDocument(filePath + '/templates/service.yaml');
-        const missingKeysService = linter.getInvalidKeyPaths(linter.getAllKeyPathsOfDocument(docService), values, docService);
+        const missingKeysService = linter.getInvalidKeyPaths(linter.getAllKeyPathElementsOfDocument(docService), values, docService);
         assert.strictEqual(missingKeysService.length, 0);
 
         const docIngress = await vscode.workspace.openTextDocument(filePath + '/templates/ingress.yaml');
-        const missingKeysIngress = linter.getInvalidKeyPaths(linter.getAllKeyPathsOfDocument(docIngress), values, docIngress);
+        const missingKeysIngress = linter.getInvalidKeyPaths(linter.getAllKeyPathElementsOfDocument(docIngress), values, docIngress);
 
         assert.strictEqual(missingKeysIngress.length, 1);
-        assert.notStrictEqual(missingKeysIngress[0], ['Missing value at path [.Values.wrong] in file [/home/tim/Coding/VSCodeExtensions/Helm-Intellisense/src/test/Test/templates/ingress.yaml:10]']);
-    });
+        assert.deepStrictEqual(missingKeysIngress[0], {
+            line: 9,
+            name: ".Values.wrong",
+            range: new vscode.Range(new vscode.Position(9, 11), new vscode.Position(9, 24)),
+            type: linter.ElementType.KEY_PATH
+        })
+    })
 });
 
-function compareTouples(touple1: [string, number][], touple2: [string, number][]): void {
-    var testVal;
-    if (touple1.length !== touple2.length) {
+function compare(elements1: linter.Element[], elements2: linter.Element[]): void {
+    if (elements1.length !== elements2.length) {
         assert.fail('No equal length');
     }
-    for (let index = 0; index < touple1.length; index++) {
-        assert.equal(touple1[index][0], touple2[index][0]);
-        assert.equal(touple1[index][1], touple2[index][1]);
+    for (let index = 0; index < elements2.length; index++) {
+        assert.strictEqual(elements1[index].name, elements2[index].name, "Name not matching for: " + elements1[index].name);
+        assert.strictEqual(elements1[index].line, elements2[index].line, "Line not matching for: " + elements1[index].name);
+        assert.strictEqual(elements1[index].range.start.character, elements2[index].range.start.character, "RangeStart not matching for: " + elements1[index].name);
+        assert.strictEqual(elements1[index].range.end.character, elements2[index].range.end.character, "RangeEnd not matching for: " + elements1[index].name);
+        assert.strictEqual(elements1[index].type, elements2[index].type, "Type not matching for: " + elements1[index].name);
     }
 }


### PR DESCRIPTION
Linked to #41 
Changed from output to be printed in a separate tab to be printed to the problems tab now. This also enables red lines below the wrongly used values within the template files.