### PR TITLE
🐛  fix handling of missing customValueFileNames

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,12 @@
 			"version": "0.13.0",
 			"dependencies": {
 				"js-yaml": "^3.13.1",
-				"merge-yaml": "^1.1.0"
+				"lodash": "^4.17.21"
 			},
 			"devDependencies": {
 				"@types/glob": "^7.1.3",
 				"@types/js-yaml": "^3.12.5",
+				"@types/lodash": "^4.14.175",
 				"@types/mocha": "^7.0.2",
 				"@types/node": "^13.13.21",
 				"@types/vscode": "^1.45.0",
@@ -87,6 +88,12 @@
 			"version": "7.0.4",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
 			"integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
+			"dev": true
+		},
+		"node_modules/@types/lodash": {
+			"version": "4.14.175",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.175.tgz",
+			"integrity": "sha512-XmdEOrKQ8a1Y/yxQFOMbC47G/V2VDO1GvMRnl4O75M4GW/abC5tnfzadQYkqEveqRM1dEJGFFegfPNA2vvx2iw==",
 			"dev": true
 		},
 		"node_modules/@types/minimatch": {
@@ -1444,13 +1451,7 @@
 		"node_modules/lodash": {
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-			"dev": true
-		},
-		"node_modules/lodash.merge": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
 		"node_modules/log-symbols": {
 			"version": "3.0.0",
@@ -1462,15 +1463,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/merge-yaml": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/merge-yaml/-/merge-yaml-1.1.0.tgz",
-			"integrity": "sha512-SBNEC9hh6Ibxrwv7DUpmVObjTrSaHeO9VTbbZ0rIIzMi/BfYXYYikj/aSgXwsCWQyaUIGsE2wZsgc5sLr/Tn3Q==",
-			"dependencies": {
-				"js-yaml": "^3.6.1",
-				"lodash.merge": "^4.6.2"
 			}
 		},
 		"node_modules/mimic-fn": {
@@ -2593,6 +2585,12 @@
 			"integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
 			"dev": true
 		},
+		"@types/lodash": {
+			"version": "4.14.175",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.175.tgz",
+			"integrity": "sha512-XmdEOrKQ8a1Y/yxQFOMbC47G/V2VDO1GvMRnl4O75M4GW/abC5tnfzadQYkqEveqRM1dEJGFFegfPNA2vvx2iw==",
+			"dev": true
+		},
 		"@types/minimatch": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -3679,13 +3677,7 @@
 		"lodash": {
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-			"dev": true
-		},
-		"lodash.merge": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
 		"log-symbols": {
 			"version": "3.0.0",
@@ -3694,15 +3686,6 @@
 			"dev": true,
 			"requires": {
 				"chalk": "^2.4.2"
-			}
-		},
-		"merge-yaml": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/merge-yaml/-/merge-yaml-1.1.0.tgz",
-			"integrity": "sha512-SBNEC9hh6Ibxrwv7DUpmVObjTrSaHeO9VTbbZ0rIIzMi/BfYXYYikj/aSgXwsCWQyaUIGsE2wZsgc5sLr/Tn3Q==",
-			"requires": {
-				"js-yaml": "^3.6.1",
-				"lodash.merge": "^4.6.2"
 			}
 		},
 		"mimic-fn": {

--- a/package.json
+++ b/package.json
@@ -71,11 +71,12 @@
 	},
 	"dependencies": {
 		"js-yaml": "^3.13.1",
-		"merge-yaml": "^1.1.0"
+		"lodash": "^4.17.21"
 	},
 	"devDependencies": {
 		"@types/glob": "^7.1.3",
 		"@types/js-yaml": "^3.12.5",
+		"@types/lodash": "^4.14.175",
 		"@types/mocha": "^7.0.2",
 		"@types/node": "^13.13.21",
 		"@types/vscode": "^1.45.0",

--- a/src/CompletionProviders/ChartCompletionItemProvider.ts
+++ b/src/CompletionProviders/ChartCompletionItemProvider.ts
@@ -3,6 +3,7 @@ import * as yaml from '../yaml';
 import * as fs from 'fs';
 import * as utils from '../utils';
 import { sep as pathSeperator } from 'path';
+import {Yaml} from "../yaml";
 
 export class ChartCompletionItemProvider implements vscode.CompletionItemProvider {
     /**
@@ -53,7 +54,7 @@ export class ChartCompletionItemProvider implements vscode.CompletionItemProvide
     /**
      * Retrieves the values from the `values.yaml`.
      */
-    private getValuesFromChartFile(document: vscode.TextDocument): any {
+    private getValuesFromChartFile(document: vscode.TextDocument): Yaml | undefined {
         const chartBasePath = utils.getChartBasePath(document.fileName);
         if (chartBasePath === undefined) {
             return undefined;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -131,7 +131,7 @@ export function getChartBasePath(fileName: string): string | undefined {
     return possiblePathToChartDirectory;
 }
 
-export function getNameOfChart(filePath: string): string {
+export function getNameOfChart(filePath: string): string | undefined {
     const chartBasePath = getChartBasePath(filePath);
     if (chartBasePath === undefined) {
         return 'No name found';
@@ -143,6 +143,9 @@ export function getNameOfChart(filePath: string): string {
     }
 
     const chartYaml = yaml.load(pathToChartFile);
+    if (chartYaml === undefined) {
+        return undefined;
+    }
     return String((chartYaml as any).name);
 }
 

--- a/src/yaml.ts
+++ b/src/yaml.ts
@@ -1,8 +1,6 @@
 import * as yaml from 'js-yaml';
 import * as fs from 'fs';
-
-// @ts-ignore
-import mergeYaml = require('merge-yaml');
+import * as lodash from 'lodash';
 
 export type Yaml = string | number | boolean | null | Yaml[] | { [key: string]: Yaml };
 
@@ -10,7 +8,11 @@ export type Yaml = string | number | boolean | null | Yaml[] | { [key: string]: 
  * Loads and returns the contents of the given file as YAML. The passed file
  * is assumed to be UTF-8 encoded.
  */
-export function load(filename: string): Yaml {
+export function load(filename: string): Yaml | undefined {
+    if (!fs.existsSync(filename)) {
+        console.error(`file ${filename} does not exist.`);
+        return undefined;
+    }
     const fileContents = fs.readFileSync(filename, {encoding: 'utf8'});
     return yaml.safeLoad(fileContents, {filename}) as Yaml;
 }
@@ -21,5 +23,12 @@ export function load(filename: string): Yaml {
  * higher index in the passed array override those with a lower index.
  */
 export function loadMerge(filenames: string[]): Yaml {
-    return mergeYaml(filenames) as Yaml;
+    let mergedValues = {};
+    for (const filename of filenames) {
+        const values = load(filename);
+        if (values !== undefined) {
+            mergedValues = lodash.merge(mergedValues, values);
+        }
+    }
+    return mergedValues;
 }


### PR DESCRIPTION
Fixes #42 by replacing the [merge-yaml](https://www.npmjs.com/package/merge-yaml) package. The functionality is basically the same as in the package (using `lodash.merge`) but adds handling for missing files.