### PR TITLE
Added feature to get all yaml files in a easier way

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,7 +49,7 @@ export function getValuesFromFile(fileName: string): any {
 
     const completeFilePaths = [];
     for (const filename of filenames) {
-        completeFilePaths.push(path.join(chartBasePath, filename));
+        completeFilePaths.push(...getAllFilesFromDirectoryRecursively(path.join(chartBasePath, filename)));
     }
 
     return yaml.loadMerge(completeFilePaths);


### PR DESCRIPTION
Earlier in customValueFileNames, we have to specify the names of all the YAML file names manually. I have changed this in such a way that now only the path of the folder is required to extract all the YAML files in that directory. This way user does not need to specify the names of all the files and it saves time. It is really handy in case you are having lots of YAML files that change very often so you can just specify the directory path for those files instead of adding all files manually.
Let me know if you have any questions or queries related to it.